### PR TITLE
Remove MCG catsrc from CI

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -68,7 +68,6 @@ oc patch operatorhub.config.openshift.io/cluster -p='{"spec":{"sources":[{"disab
 
 echo "Creating secret for CI builds in ${NAMESPACE}"
 createSecret ${NAMESPACE}
-oc apply -f openshift-ci/mcg-ms-catalog-source.yaml
 
 echo "Waiting for CatalogSource to be Ready"
 # Have to sleep here for atleast 1 min to ensure catalog source is in stable READY state


### PR DESCRIPTION
The CI does not depend on mcg-ms catsrc now, since we are using our own there: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28265/rehearse-28265-pull-ci-red-hat-storage-mcg-ms-console-master-mcg-ms-console-e2e-aws/1529851059302830080#1:build-log.txt%3A74