### PR TITLE
E2E code cleanup

### DIFF
--- a/cypress/support.ts
+++ b/cypress/support.ts
@@ -1,15 +1,7 @@
 /* eslint-disable cypress/require-data-selectors */
-import './support/selectors';
 import './support/login';
+import './support/selectors';
 /* import all support files above */
-
-declare global {
-  namespace Cypress {
-    interface Chainable<Subject> {
-      install(encrypted?: boolean): Chainable<Element>;
-    }
-  }
-}
 
 Cypress.on('uncaught:exception', () => {
   // don't fail on Cypress' internal errors.

--- a/cypress/support/login.ts
+++ b/cypress/support/login.ts
@@ -59,7 +59,7 @@ Cypress.Commands.add('logout', () => {
     cy.task('log', '  Logging out');
     cy.byTestID('user-dropdown').click();
     cy.byTestID('log-out').should('be.visible');
-    cy.byTestID('log-out').click({ force: true });
+    cy.byTestID('log-out').click({ force: true }); // eslint-disable-line cypress/no-force
     cy.byLegacyTestID('login').should('be.visible');
   });
 });

--- a/cypress/support/selectors.ts
+++ b/cypress/support/selectors.ts
@@ -17,6 +17,7 @@ declare global {
       byTestDropDownMenu(selector: string): Chainable<Element>;
       byTestOperandLink(selector: string): Chainable<Element>;
       byTestRows(selector: string): Chainable<Element>;
+      byTestSelector(selector: string): Chainable<Element>;
       clickNavLink(path: [string, string?]): Chainable<Element>;
       byTestOperatorRow(
         selector: string,
@@ -43,6 +44,9 @@ Cypress.Commands.add(
   }
 );
 
+/**
+ * Only use it for openshift/console elements that still use this selector.
+ */
 Cypress.Commands.add('byLegacyTestID', (selector: string) => {
   cy.get(`[data-test-id="${selector}"]`);
 });
@@ -53,6 +57,10 @@ Cypress.Commands.add('byTestOperandLink', (selector: string) => {
 
 Cypress.Commands.add('byTestRows', (selector: string) => {
   cy.get(`[data-test-rows="${selector}"]`);
+});
+
+Cypress.Commands.add('byTestSelector', (selector: string) => {
+  cy.get(`[data-test-selector="${selector}"]`);
 });
 
 Cypress.Commands.add('byTestActionID', (selector: string) => {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "cypress-generate": "marge -o ./cypress-gen/ -f cypress-report -t 'OpenShift Console Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ./cypress-gen/cypress/assets ./cypress-gen/cypress.json",
     "cypress-postreport": "yarn cypress-merge && yarn cypress-generate",
     "test-cypress": "node_modules/.bin/cypress open --config-file ./cypress/cypress.json --env openshift=true",
+    "test-cypress-with-op-install": "./e2e-ops.sh && yarn test-cypress",
     "test-cypress-headless": "node --max-old-space-size=4096 node_modules/.bin/cypress run --config-file ./cypress/cypress.json --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless",
     "clean": "rm -rf dist",
     "build": "yarn clean && NODE_ENV=production yarn ts-node node_modules/.bin/webpack",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "i18n": "i18next \"packages/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js",
     "lint-css": "yarn stylelint packages/**/**/*.scss",
     "lint-css-fix": "yarn stylelint packages/**/**/*.scss --fix",
-    "lint": "yarn eslint --ext .ts,.tsx ./packages/ && yarn lint-css",
-    "lint-fix": "yarn eslint --fix --ext .ts,.tsx ./packages/ && yarn lint-css-fix",
+    "lint": "yarn eslint --ext .ts,.tsx ./packages/ ./cypress/ && yarn lint-css",
+    "lint-fix": "yarn eslint --fix --ext .ts,.tsx ./packages/ ./cypress/ && yarn lint-css-fix",
     "prepare": "husky install",
-    "format-test": "yarn prettier -c .",
-    "format": "yarn prettier -w .",
+    "format-test": "yarn prettier -c ./packages/ ./cypress/",
+    "format": "yarn prettier -w ./packages/ ./cypress/",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "husky install",
     "format-test": "yarn prettier -c .",
     "format": "yarn prettier -w .",
-    "ts-node": "ts-node -O '{\"module\":\"commonjs\"}' -I '/node_modules/(?!(@odf)/)/'"
+    "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'"
   },
   "dependencies": {
     "@patternfly/patternfly": "4.103.6",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}' -I '/node_modules/(?!(@odf)/)/'"
   },
   "dependencies": {
-    "@cypress/webpack-preprocessor": "^5.11.1",
     "@patternfly/patternfly": "4.103.6",
     "@patternfly/react-charts": "^6.15.3",
     "@patternfly/react-core": "4.175.4",
@@ -35,8 +34,6 @@
     "@patternfly/react-table": "^4.29.0",
     "@types/react-dnd-html5-backend": "^3.0.2",
     "classnames": "^2.3.1",
-    "cypress": "^9.6.1",
-    "cypress-multi-reporters": "^1.6.0",
     "fuzzysearch": "^1.0.3",
     "lodash-es": "^4.17.21",
     "loglevel": "1.8.0",
@@ -54,6 +51,7 @@
     "react-tagsinput": "^3.19.0"
   },
   "devDependencies": {
+    "@cypress/webpack-preprocessor": "5.12.0",
     "@openshift-console/dynamic-plugin-sdk": "0.0.3",
     "@openshift-console/dynamic-plugin-sdk-internal": "0.0.2",
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.4",
@@ -70,6 +68,8 @@
     "comment-json": "4.x",
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "0.28.x",
+    "cypress": "9.7.0",
+    "cypress-multi-reporters": "1.6.1",
     "eslint": "^7.31.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-typescript": "^2.7.1",

--- a/packages/components/bucket-policy/bucket-policy-footer.tsx
+++ b/packages/components/bucket-policy/bucket-policy-footer.tsx
@@ -28,7 +28,7 @@ export const BucketPolicyFooter: React.FC<BucketPolicyFooterProps> = ({
         <Button
           type="button"
           variant="primary"
-          data-test-id="confirm-action-bucket"
+          data-test="confirm-action-bucket"
           onClick={onConfirm}
           isDisabled={!checkRequiredValues(state) || !loaded || !!error}
         >
@@ -37,7 +37,7 @@ export const BucketPolicyFooter: React.FC<BucketPolicyFooterProps> = ({
         <Button
           type="button"
           variant="secondary"
-          data-test-id="cancel-action-bucket"
+          data-test="cancel-action-bucket"
           onClick={onCancel}
         >
           {t('Cancel')}

--- a/packages/components/modals/data-resource/modal-status.tsx
+++ b/packages/components/modals/data-resource/modal-status.tsx
@@ -130,7 +130,7 @@ const DataResourceStatus: React.FC<DataResourceStatusProps> = React.memo(
                 variant={buttonProp.variant}
                 isDisabled={buttonProp?.disable}
                 key={buttonProp.id}
-                data-test-id={buttonProp.id}
+                data-test={buttonProp.id}
                 onClick={buttonProp?.onClick}
                 isLoading={buttonProp?.loading}
               >

--- a/packages/utils/details-page/DetailsPage.tsx
+++ b/packages/utils/details-page/DetailsPage.tsx
@@ -298,7 +298,7 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
   const canUpdate = canUpdateAccess && canUpdateResource;
 
   return (
-    <dl data-test-id="resource-summary" className="co-m-pane__details">
+    <dl data-test="resource-summary" className="co-m-pane__details">
       <DetailsItem
         label={t('Name')}
         obj={resource}

--- a/packages/utils/error/Errors.tsx
+++ b/packages/utils/error/Errors.tsx
@@ -14,7 +14,7 @@ const ErrorComponent: React.SFC<ErrorComponentProps> = ({ title, message }) => {
   return (
     <>
       <PageHeading title={t('Error')} />
-      <div className="co-m-pane__body" data-test-id="error-page">
+      <div className="co-m-pane__body" data-test="error-page">
         <PageHeading title={title} centerText />
         {message && <div className="pf-u-text-align-center">{message}</div>}
       </div>

--- a/packages/utils/generics/NameValueEditor.tsx
+++ b/packages/utils/generics/NameValueEditor.tsx
@@ -304,7 +304,7 @@ export const NameValueEditor: React.FC<NameValueEditorProps> =
                     variant="link"
                   >
                     <PlusCircleIcon
-                      data-test-id="pairs-list__add-icon"
+                      data-test="pairs-list__add-icon"
                       className="co-icon-space-r"
                     />
                     {addString ? addString : t('Add more')}

--- a/packages/utils/generics/link.tsx
+++ b/packages/utils/generics/link.tsx
@@ -88,7 +88,7 @@ export const ExternalLink: React.FC<ExternalLinkProps> = ({
     href={href}
     target="_blank"
     rel="noopener noreferrer"
-    data-test-id={dataTestID}
+    data-test={dataTestID}
     {...(stopPropagation ? { onClick: (e) => e.stopPropagation() } : {})}
   >
     {children || text}
@@ -121,7 +121,7 @@ export const ExternalLinkWithCopy: React.FC<ExternalLinkWithCopyProps> = ({
         href={link}
         target="_blank"
         rel="noopener noreferrer"
-        data-test-id={dataTestID}
+        data-test={dataTestID}
       >
         {text ?? link}
       </a>

--- a/packages/utils/heading/page-heading.tsx
+++ b/packages/utils/heading/page-heading.tsx
@@ -30,7 +30,7 @@ const BreadCrumbs: React.FC<BreadCrumbsProps> = ({ breadcrumbs }) => (
             <Link
               className="pf-c-breadcrumb__link"
               to={crumb.path}
-              data-test-id={`breadcrumb-link-${i}`}
+              data-test={`breadcrumb-link-${i}`}
             >
               {crumb.name}
             </Link>
@@ -103,7 +103,7 @@ const PageHeading: React.FC<PageHeadingProps> = (props) => {
         >
           <div className="co-m-pane__name co-resource-item">
             <span
-              data-test-id="resource-title"
+              data-test="resource-title"
               className="co-resource-item__resource-name"
             >
               {resourceTitle}
@@ -116,7 +116,7 @@ const PageHeading: React.FC<PageHeadingProps> = (props) => {
           </div>
         </h1>
         {showActions && (
-          <div className="co-actions" data-test-id="details-actions">
+          <div className="co-actions" data-test="details-actions">
             {actions()}
           </div>
         )}

--- a/prow.sh
+++ b/prow.sh
@@ -40,6 +40,9 @@ export NO_COLOR=1
 export BRIDGE_BASE_ADDRESS
 export BRIDGE_KUBEADMIN_PASSWORD
 
+# Install the addon.
+./e2e-ops.sh
+
 # Install dependencies.
 yarn install
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,10 +368,10 @@
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
-"@cypress/webpack-preprocessor@^5.11.1":
-  version "5.11.1"
-  resolved "https://registry.yarnpkg.com/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.11.1.tgz#697d830e40eab7b63d37981863f6319098e6b78e"
-  integrity sha512-kfdF+W/Tns81rFplnqlgZ+t6V+FJ7vegeQCYolLyhh0nJ8eG3s5HvV/ak/zSlbQnaOmAuYiZIChJFVZLUWuNOA==
+"@cypress/webpack-preprocessor@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.12.0.tgz#231f6c86423237e17eaf12ce6193d4b67290b852"
+  integrity sha512-D/eLKKlgx6c/307FaCmjZGjFA64G29aA8KcCy6WqpNK/bSnRdPquMW2plemIsT/B80TK2DDKzZX/H3FcS41ZDA==
   dependencies:
     bluebird "3.7.1"
     debug "^4.3.2"
@@ -3104,18 +3104,18 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-cypress-multi-reporters@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/cypress-multi-reporters/-/cypress-multi-reporters-1.6.0.tgz#2c6833b92e3df412c233657c55009e2d5e1cc7c1"
-  integrity sha512-JN9yMzDmPwwirzi95N2FC8VJZ0qp+uUJ1ixYHpJFaAtGgIx15LjVmASqQaxnDh8q57jIIJ6C0o7imiLU6N1YNQ==
+cypress-multi-reporters@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/cypress-multi-reporters/-/cypress-multi-reporters-1.6.1.tgz#515b891f6c80e0700068efb03ab9d55388399c95"
+  integrity sha512-FPeC0xWF1N6Myrwc2m7KC0xxlrtG8+x4hlsPFBDRWP8u/veR2x90pGaH3BuJfweV7xoQ4Zo85Qjhu3fgZGrBQQ==
   dependencies:
     debug "^4.1.1"
     lodash "^4.17.15"
 
-cypress@^9.6.1:
-  version "9.6.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.6.1.tgz#a7d6b5a53325b3dc4960181f5800a5ade0f085eb"
-  integrity sha512-ECzmV7pJSkk+NuAhEw6C3D+RIRATkSb2VAHXDY6qGZbca/F9mv5pPsj2LO6Ty6oIFVBTrwCyL9agl28MtJMe2g==
+cypress@9.7.0:
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.7.0.tgz#bf55b2afd481f7a113ef5604aa8b693564b5e744"
+  integrity sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
- Move cypress deps. to devDependencies.
- ts-node script: remove unneeded 'ignore' flag. 
- Remove the data-test-id selectors.
- Add 'ByTestSelector' method.
- Add the cypress folder to lint commands.
- New yarn command "test-cypress-with-op-install" that also installs operator.
- E2E CI scripts: install operator before running cypress.
