### PR TITLE
fix: added some css padding to various screens

### DIFF
--- a/packages/components/bucket-policy/bucket-policy.scss
+++ b/packages/components/bucket-policy/bucket-policy.scss
@@ -3,6 +3,7 @@
     margin: var(--pf-global--spacer--lg) var(--pf-global--spacer--lg) 0
       var(--pf-global--spacer--lg);
     max-width: 75%;
+    padding-bottom: 20vh;
   }
 
   &__form--margin-bottom {

--- a/packages/components/dashboard/resource-providers-card/resource-providers-card.scss
+++ b/packages/components/dashboard/resource-providers-card/resource-providers-card.scss
@@ -35,7 +35,3 @@
 .nb-resource-providers-card__status-icon {
   color: $pf-color-black-700;
 }
-
-.co-inventory-card__item {
-  padding-left: var(--pf-c-card--child--PaddingLeft);
-}

--- a/packages/components/dashboard/resource-providers-card/resource-providers-card.tsx
+++ b/packages/components/dashboard/resource-providers-card/resource-providers-card.tsx
@@ -19,12 +19,10 @@ import './resource-providers-card.scss';
 const ResourceProvidersItem: React.FC<ResourceProvidersRowProps> =
   // eslint-disable-next-line react/display-name
   React.memo(({ title, count }) => (
-    <div className="co-inventory-card__item">
-      <div
-        className="nb-resource-providers-card__row-title"
-        data-test="nb-resource-providers-card"
-      >{`${count} ${title}`}</div>
-    </div>
+    <div
+      className="nb-resource-providers-card__row-title"
+      data-test="nb-resource-providers-card"
+    >{`${count} ${title}`}</div>
   ));
 
 const ResourceProviders: React.FC<{}> = () => {

--- a/packages/components/data-resource/data-resource.scss
+++ b/packages/components/data-resource/data-resource.scss
@@ -32,7 +32,7 @@
 .nb-endpoints-form {
   margin-bottom: var(--pf-global--spacer--lg);
   margin-top: var(--pf-global--spacer--lg);
-  padding-bottom: 100px;
+  padding-bottom: 10vh;
   width: 100%;
 }
 


### PR DESCRIPTION
**Resource card fix -** 

**Before:** 
![image](https://user-images.githubusercontent.com/22158580/181272993-a842af79-ec97-4d75-afff-3ed087f8e4ee.png)

**After:**
![image](https://user-images.githubusercontent.com/22158580/180257080-355f1862-075f-41ae-856b-5411a0d55ff6.png)

--------------------------------------------------------------------------------------------------------------------

**Added padding -** 

**Before: (no padding when the dropdown opens) Bucket creation page**
![image](https://user-images.githubusercontent.com/22158580/181275956-d6766e61-3779-43ec-b58b-ca361c919a26.png)

**After: (now there is padding after the dropdown opens) Bucket creation page**
![image](https://user-images.githubusercontent.com/22158580/181275159-7e0b49b6-9eee-4ad0-8046-d9d943e530d9.png)

--------------------------------------------------------------------------------------------------------------------
Here earlier we were using hardcoded pixels, now made it relative.
![image](https://user-images.githubusercontent.com/22158580/181277276-2b67b917-2251-401b-908c-b2bba53c278b.png)

