### PR TITLE
E2E: skip tests when required data does not exist.

### DIFF
--- a/cypress/constants/tests.ts
+++ b/cypress/constants/tests.ts
@@ -27,3 +27,8 @@ export const DATA_SOURCE_INPUTS = {
   secretKey: Cypress.env('AWS_SECRET_ACCESS_KEY'),
   targetBucket: Cypress.env('AWS_SINGLE_DATA_SOURCE_BUCKET'),
 };
+
+// Helper constants.
+export const AWS_CREDS_EXIST: boolean = !!(
+  Cypress.env('AWS_ACCESS_KEY_ID') && Cypress.env('AWS_SECRET_ACCESS_KEY')
+);

--- a/cypress/support.ts
+++ b/cypress/support.ts
@@ -1,4 +1,5 @@
 /* eslint-disable cypress/require-data-selectors */
+import '@cypress/skip-test/support';
 import './support/login';
 import './support/selectors';
 /* import all support files above */

--- a/cypress/tests/data-source.spec.ts
+++ b/cypress/tests/data-source.spec.ts
@@ -1,5 +1,6 @@
 import { DATA_FEDERATION_NAMESPACE, MINUTE } from '../constants/common';
 import {
+  AWS_CREDS_EXIST,
   DATA_SOURCE_INPUTS,
   Providers,
   TEST_DATA_SOURCE,
@@ -37,6 +38,7 @@ describe('data source creation', () => {
   });
 
   it('creates a data source having AWS as the provider', () => {
+    cy.onlyOn(AWS_CREDS_EXIST);
     createDataSource(Providers.AWS, TEST_DATA_SOURCE);
     checkDataSourceCreation(TEST_DATA_SOURCE, DATA_FEDERATION_NAMESPACE);
     cy.byTestID(`status-text`).should('contain', 'Ready');

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "3.131.0",
+    "@cypress/skip-test": "2.6.1",
     "@cypress/webpack-preprocessor": "5.12.0",
     "@openshift-console/dynamic-plugin-sdk": "0.0.3",
     "@openshift-console/dynamic-plugin-sdk-internal": "0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,6 +1251,11 @@
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
+"@cypress/skip-test@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@cypress/skip-test/-/skip-test-2.6.1.tgz#44a4bc4c2b2e369a7661177c9b38e50d417a36ea"
+  integrity sha512-X+ibefBiuOmC5gKG91wRIT0/OqXeETYvu7zXktjZ3yLeO186Y8ia0K7/gQUpAwuUi28DuqMd1+7tBQVtPkzbPA==
+
 "@cypress/webpack-preprocessor@5.12.0":
   version "5.12.0"
   resolved "https://registry.yarnpkg.com/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.12.0.tgz#231f6c86423237e17eaf12ce6193d4b67290b852"


### PR DESCRIPTION
1st use case: skip tests that require AWS credentials but they're not present.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>