### PR TITLE
build script fix: enforce production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build-dev": "yarn clean && yarn ts-node ./node_modules/.bin/webpack",
     "dev": "yarn clean && yarn ts-node ./node_modules/.bin/webpack serve",
     "http-server": "./http-server.sh dist",
+    "http-server-local": "http-server dist -p 9002 -c-1 --cors",
     "i18n": "i18next \"packages/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js",
     "lint-css": "yarn stylelint packages/**/**/*.scss",
     "lint-css-fix": "yarn stylelint packages/**/**/*.scss --fix",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test-cypress-with-ci-hooks": "yarn e2e:ci-pre && yarn test-cypress && yarn e2e:ci-post",
     "test-cypress-headless": "node --max-old-space-size=4096 node_modules/.bin/cypress run --config-file ./cypress/cypress.json --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless",
     "clean": "rm -rf dist",
-    "build": "yarn clean && NODE_ENV=production yarn ts-node node_modules/.bin/webpack",
+    "build": "yarn clean && yarn ts-node node_modules/.bin/webpack --mode=production",
     "build-dev": "yarn clean && yarn ts-node ./node_modules/.bin/webpack",
     "dev": "yarn clean && yarn ts-node ./node_modules/.bin/webpack serve",
     "http-server": "./http-server.sh dist",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -88,7 +88,6 @@ const config: webpack.Configuration = {
   devtool: 'cheap-module-source-map',
   optimization: {
     chunkIds: 'named',
-    minimize: false,
   },
 };
 


### PR DESCRIPTION
[Webpack documentation](https://webpack.js.org/configuration/mode/#usage) says: "If mode is not provided via configuration or CLI, CLI will use any valid NODE_ENV value for mode."
But we have 'development' mode hardcoded in the config, so now production is enforced via CLI argument.

`dist` folder size:
BEFORE optimizations: 4,2M
AFTER optimizations:  676K    <==

Signed-off-by: Alfonso Martínez <almartin@redhat.com>