### PR TITLE
fix: added the option to view  cached data source in list page

### DIFF
--- a/packages/components/resource-pages/data-resource-list-view.tsx
+++ b/packages/components/resource-pages/data-resource-list-view.tsx
@@ -162,6 +162,9 @@ export const useDataResourceList = () => {
                     ? [...bcMap[ns], bucketName]
                     : [bucketName])
               );
+            } else if (namespacePolicy?.type === BucketClassType.CACHE) {
+              const ns = namespacePolicy?.cache?.hubResource;
+              bcMap[ns] = bcMap[ns] ? [...bcMap[ns], bucketName] : [bucketName];
             }
             return bcMap;
           }, {})


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/DFMS-227

![image](https://user-images.githubusercontent.com/22158580/182780120-efd61d5e-21ad-45c4-9109-cd282a804de4.png)

![image](https://user-images.githubusercontent.com/22158580/182780158-036689d6-8f18-4129-87c7-8963951fb0d3.png)

![image](https://user-images.githubusercontent.com/22158580/182780243-5f116063-fc22-4570-be01-74b945cd0f49.png)

Note: the text changes are not here yet, once it is merged will take a screenshot and attach it here.