### PR TITLE
CI E2E fixes

### DIFF
--- a/ci/e2e/pre-hook.sh
+++ b/ci/e2e/pre-hook.sh
@@ -12,6 +12,9 @@ set -eExuo pipefail
 # Run the AWS pre-tests hook.
 yarn ts-node ci/e2e/aws-hooks.ts pre-tests
 
+export DEFAULT_WAIT_SLEEP_SECONDS=10
+DEFAULT_WAIT_TIMEOUT="30m"
+
 function installMCGAddon {
     declare -a resources=() # Recent BASH change, refer https://stackoverflow.com/a/28058737.
     resources=("namespace" "secrets" "operatorgroup" "catalogsource" "subscription")
@@ -19,24 +22,33 @@ function installMCGAddon {
         oc create -f "https://raw.githubusercontent.com/red-hat-storage/mcg-osd-deployer/main/hack/deploy/${resource}.yaml"
     done
 }
+function printTimestamp {
+    date -u +%H:%M:%S
+}
 function waitUntilCSVExists {
     until [[ $(oc get csv -n redhat-data-federation | grep -c "$1") -gt 0 ]]; do
-        echo "Waiting for $1 to exist..."
-        sleep 5
+        echo "$(printTimestamp)  Waiting for $1 to exist..."
+        sleep ${DEFAULT_WAIT_SLEEP_SECONDS}
     done
 }
 function waitUntilCSVIsReady {
     until [[ $(oc get csv -n redhat-data-federation -o=jsonpath="{.items[?(@.spec.displayName==\"$1\")].status.phase}") == "Succeeded" ]]; do
-        echo "Waiting for $1 to reach succeeded state..."
-        sleep 5
+        if [[ $(oc get deploy -n redhat-data-federation | grep -c mcg-osd-deployer-controller-manager) -gt 0 \
+              && $(oc set env deploy/mcg-osd-deployer-controller-manager --list -n redhat-data-federation | grep -c "RHOBS_ENDPOINT") -eq 0 ]]; then
+            echo "Setting required data for the addon manager..."
+            oc set env deploy/mcg-osd-deployer-controller-manager -n redhat-data-federation \
+              ADDON_ENVIRONMENT="ci" ADDON_VARIANT="ci" RHOBS_ENDPOINT="https://example.com/receive" RH_SSO_TOKEN_ENDPOINT="https://example.com/token"
+        fi
+        echo "$(printTimestamp)  Waiting for $1 to reach succeeded state..."
+        sleep ${DEFAULT_WAIT_SLEEP_SECONDS}
     done
 }
 
-export -f waitUntilCSVExists waitUntilCSVIsReady
+export -f printTimestamp waitUntilCSVExists waitUntilCSVIsReady
 export MCG_DISPLAY_NAME="MCG OSD Deployer"
 # Check if the addon is already successfully installed.
 if [[ $(oc get csv -n redhat-data-federation | grep -c mcg-osd-deployer) -gt 0 ]]; then
-    timeout 10m bash -c "waitUntilCSVIsReady \"${MCG_DISPLAY_NAME}\""
+    timeout "${DEFAULT_WAIT_TIMEOUT}" bash -c "waitUntilCSVIsReady \"${MCG_DISPLAY_NAME}\""
     exit 0
 fi
 
@@ -44,12 +56,12 @@ fi
 installMCGAddon
 
 # Wait until the operator CSV exists.
-timeout 10m bash -c "waitUntilCSVExists \"${MCG_DISPLAY_NAME}\""
+timeout "${DEFAULT_WAIT_TIMEOUT}" bash -c "waitUntilCSVExists \"${MCG_DISPLAY_NAME}\""
 # Check if the CSV installation succeeded.
-timeout 10m bash -c "waitUntilCSVIsReady \"${MCG_DISPLAY_NAME}\""
+timeout "${DEFAULT_WAIT_TIMEOUT}" bash -c "waitUntilCSVIsReady \"${MCG_DISPLAY_NAME}\""
 
 # Don't run in a local environment.
-: ${OPENSHIFT_CI:=}
+: "${OPENSHIFT_CI:=}"
 if [[ -n "${OPENSHIFT_CI}" ]]; then
     # Fetch the operator CSV name.
     MCG_CSV_NAME="$(oc get csv -n redhat-data-federation -o=jsonpath="{.items[?(@.spec.displayName==\"${MCG_DISPLAY_NAME}\")].metadata.name}")"
@@ -57,6 +69,6 @@ if [[ -n "${OPENSHIFT_CI}" ]]; then
     MCG_CONSOLE_IMAGE="$1"
     oc patch csv "${MCG_CSV_NAME}" -n redhat-data-federation --type='json' -p \
         "[{'op': 'replace', 'path': '/spec/install/spec/deployments/1/spec/template/spec/containers/0/image', 'value': \"${MCG_CONSOLE_IMAGE}\"}]"
-    sleep 10
-    timeout 10m bash -c "waitUntilCSVIsReady \"${MCG_DISPLAY_NAME}\""
+    sleep ${DEFAULT_WAIT_SLEEP_SECONDS}
+    timeout "${DEFAULT_WAIT_TIMEOUT}" bash -c "waitUntilCSVIsReady \"${MCG_DISPLAY_NAME}\""
 fi


### PR DESCRIPTION
* Add required env. variables for the addon manager deployment.
* Increase timeout values.
* Move the cypress-gen folder to the artifacts folder only if cypress-gen exists.
* Shellcheck fixes.


Signed-off-by: Alfonso Martínez <almartin@redhat.com>