### PR TITLE
fix: css for obc credentials copy to clipboard

### DIFF
--- a/packages/utils/generics/copy-to-clipboard.scss
+++ b/packages/utils/generics/copy-to-clipboard.scss
@@ -1,0 +1,32 @@
+pre {
+  background-color: var(--pf-c-code-block--BackgroundColor);
+  color: var(--pf-global--Color--100);
+  display: block;
+  font-family: var(--pf-c-code-block__pre--FontFamily);
+  font-size: var(--pf-c-code-block__pre--FontSize);
+  overflow-wrap: break-word;
+  padding: var(--pf-global--spacer--md);
+  white-space: pre-wrap;
+}
+
+.copy-to-clipboard__text {
+  padding-right: 50px;
+}
+
+.copy-to-clipboard__btn,
+.copy-to-clipboard__btn:hover {
+  --pf-c-button--PaddingTop: 11px;
+  --pf-c-button--PaddingRight: 16px;
+  --pf-c-button--PaddingBottom: 11px;
+  --pf-c-button--PaddingLeft: 16px;
+  --pf-c-button--BorderColor: #ccc;
+  --pf-c-button--BorderRadius: 0;
+  --pf-c-button--hover--BorderWidth: 1px;
+  --pf-c-button--LineHeight: 20px;
+}
+
+.clipboard-copy__group-copy {
+  position: absolute;
+  right: 0;
+  top: 3px;
+}

--- a/packages/utils/generics/copy-to-clipboard.tsx
+++ b/packages/utils/generics/copy-to-clipboard.tsx
@@ -4,6 +4,7 @@ import { CopyToClipboard as CTC } from 'react-copy-to-clipboard';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { CopyIcon } from '@patternfly/react-icons';
 import { useCustomTranslation } from '../hooks/useCustomTranslationHook';
+import './copy-to-clipboard.scss';
 
 export const CopyToClipboard: React.FC<CopyToClipboardProps> = React.memo(
   (props) => {
@@ -25,7 +26,7 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = React.memo(
     return (
       <div className="co-copy-to-clipboard">
         <pre
-          className="co-pre-wrap co-copy-to-clipboard__text"
+          className="co-pre-wrap copy-to-clipboard__text"
           data-test="copy-to-clipboard"
         >
           {visibleValue}
@@ -39,7 +40,7 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = React.memo(
             <Button
               variant="plain"
               onMouseEnter={() => setCopied(false)}
-              className="co-copy-to-clipboard__btn pf-c-clipboard-copy__group-copy"
+              className="copy-to-clipboard__btn clipboard-copy__group-copy"
               type="button"
             >
               <CopyIcon />


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/DFMS-208

after:
![image](https://user-images.githubusercontent.com/22158580/187398578-45f6d02a-8691-47d1-a484-801c95c51c9f.png)

before:
![image](https://user-images.githubusercontent.com/22158580/187398718-4b36e8e7-7f11-46d3-9ae8-0801c08ef25a.png)
